### PR TITLE
Allow nightly and beta channels to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
 language: rust
-sudo: false
-addons:
-  apt:
-    packages:
-      - libgl1-mesa-dev
 
-matrix:
-  include:
-    - os: osx
-      rust: stable
-    - os: osx
-      rust: nightly
-    - os: linux
-      rust: stable
-    - os: linux
-      rust: nightly
+rust:
+    - stable
+    - beta
+    - nightly
+
+sudo: false
+
+addons:
+    apt:
+        packages:
+            - libgl1-mesa-dev
+
+os:
+    - linux
+    - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,8 @@ addons:
 os:
     - linux
     - osx
+
+matrix:
+    allow_failures:
+        - rust: nightly
+        - rust: beta


### PR DESCRIPTION
Since they aren't stable it's probably best to let them fail. Found this out when trying to update the serde dependency.