### PR TITLE
Remove AsRef from open to remove the code bloat

### DIFF
--- a/src/v1/mod.rs
+++ b/src/v1/mod.rs
@@ -184,7 +184,7 @@ pub struct Gltf {
 }
 
 impl Gltf {
-    pub fn open<P: AsRef<Path>>(path: P) -> Result<Self, Error> {
+    pub fn open(path: &Path) -> Result<Self, Error> {
         let mut file = File::open(path)?;
         let mut json = String::new();
         file.read_to_string(&mut json)?;


### PR DESCRIPTION
See https://github.com/rust-lang/rust/issues/41782

I guess we could also make the generic `open` function a free standing function.