### PR TITLE
Make texture sampler optional

### DIFF
--- a/src/v2/texture.rs
+++ b/src/v2/texture.rs
@@ -118,7 +118,7 @@ pub struct Texture {
     pub internal_format: Format,
 
     /// The index of the sampler used by this texture.
-    pub sampler: Index<Sampler>,
+    pub sampler: Option<Index<Sampler>>,
 
     /// The index of the image used by this texture.
     pub source: Index<image::Image>,
@@ -181,7 +181,9 @@ impl Sampler {
 impl Texture {
     #[doc(hidden)]
     pub fn range_check(&self, root: &Root) -> Result<(), ()> {
-        let _ = root.try_get(&self.sampler)?;
+        if let Some(ref sampler) = self.sampler {
+            let _ = root.try_get(sampler)?;
+        }
         let _ = root.try_get(&self.source)?;
         Ok(())
     }

--- a/tests/import_v2.rs
+++ b/tests/import_v2.rs
@@ -13,7 +13,7 @@ fn import_v2() {
         match gltf::v2::import(asset) {
             Ok(_) => {}
             Err(err) => {
-                println!("{:?}", err);
+                println!("{}: {:?}", asset, err);
                 panic!()
             }
         }


### PR DESCRIPTION
Partial fix for #20:
The tests failed on `Corso.gltf` because it doesn't have `sampler` attributes on its `textures`. According to the spec, the field is not required: https://github.com/KhronosGroup/glTF/tree/2.0/specification/2.0#texture