### PR TITLE
Minor improvement to Wrapper branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ include = [
 ]
 
 [dependencies]
-serde = "1.0"
-serde_derive = "1.0"
-serde_json = "1.0"
+serde = "1"
+serde_derive = "1"
+serde_json = "1"
 gltf_derive = { path = "./gltf_derive" }
 
 [features]
@@ -27,4 +27,3 @@ extras = []
 [[example]]
 name = "gltf_display"
 path = "examples/display/main.rs"
-

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,12 @@
+chain_one_line_max = 80
+closure_block_indent_threshold = -1
+condense_wildcard_suffixes = true
+error_on_line_overflow = false
+max_width = 80
+reorder_imported_names = true
+reorder_imports = true
+reorder_imports_in_group = true
+take_source_hints = true
+where_style = "Legacy"
+wrap_comments = true
+fn_args_layout = "Visual"


### PR DESCRIPTION
This PR brings tiny improvement: it uses serde_json::from_reader instead of from_slice.  The advantage is that it does not need to load raw glTF data anymore but rather lets serde_json read and parse as it needs.  It brings tiny memory usage improvement since serde_json parses char by char and reads as it needs and never keeps whole raw thing in memory.  This removes Importer::gltf field as it is deemed redundant and unneeded.

Additionally, this PR changes to use all upcoming minor versions of 1.x.x of serde and brings rustfmt.toml which should be mostly compatible with the style that is already used in project.