### PR TITLE
Allow the validation process to end early

### DIFF
--- a/src/import.rs
+++ b/src/import.rs
@@ -58,7 +58,11 @@ fn import_impl(path: &Path) -> Result<Root, Error> {
     };
 
     let mut errs = Vec::new();
-    root.validate(&root, || JsonPath::new(), &mut |err| errs.push(err));
+    root.validate(&root, || JsonPath::new(), &mut |err| {
+        errs.push(err);
+        // Validate the whole glTF
+        validation::Action::Continue
+    });
     if errs.is_empty() {
         Ok(root)
     } else {

--- a/src/json/accessor.rs
+++ b/src/json/accessor.rs
@@ -8,7 +8,7 @@
 // except according to those terms.
 
 use json::{buffer, Extras, Index, Root};
-use validation::{Error, JsonPath, Validate};
+use validation::{Action, Error, JsonPath, Validate};
 
 /// Corresponds to `GL_BYTE`.
 pub const BYTE: u32 = 5120;
@@ -227,31 +227,37 @@ pub struct GenericComponentType(pub u32);
 pub struct Type(pub String);
 
 impl Validate for IndexComponentType {
-    fn validate<P, R>(&self, _: &Root, path: P, report: &mut R)
-        where P: Fn() -> JsonPath, R: FnMut(Error)
+    fn validate<P, R>(&self, _: &Root, path: P, report: &mut R) -> Action
+        where P: Fn() -> JsonPath, R: FnMut(Error) -> Action
     {
-        if !VALID_INDEX_COMPONENT_TYPES.contains(&self.0) {
-            report(Error::invalid_enum(path(), self.0));
+        if VALID_INDEX_COMPONENT_TYPES.contains(&self.0) {
+            Action::Continue
+        } else {
+            report(Error::invalid_enum(path(), self.0))
         }
     }
 }
 
 impl Validate for GenericComponentType {
-    fn validate<P, R>(&self, _: &Root, path: P, report: &mut R)
-        where P: Fn() -> JsonPath, R: FnMut(Error)
+    fn validate<P, R>(&self, _: &Root, path: P, report: &mut R) -> Action
+        where P: Fn() -> JsonPath, R: FnMut(Error) -> Action
     {
-        if !VALID_GENERIC_ATTRIBUTE_COMPONENT_TYPES.contains(&self.0) {
-            report(Error::invalid_enum(path(), self.0));
+        if VALID_GENERIC_ATTRIBUTE_COMPONENT_TYPES.contains(&self.0) {
+            Action::Continue
+        } else {
+            report(Error::invalid_enum(path(), self.0))
         }
     }
 }
 
 impl Validate for Type {
-    fn validate<P, R>(&self, _: &Root, path: P, report: &mut R)
-        where P: Fn() -> JsonPath, R: FnMut(Error)
+    fn validate<P, R>(&self, _: &Root, path: P, report: &mut R) -> Action
+        where P: Fn() -> JsonPath, R: FnMut(Error) -> Action
     {
-        if !VALID_ACCESSOR_TYPES.contains(&self.0.as_str()) {
-            report(Error::invalid_enum(path(), self.0.clone()));
+        if VALID_ACCESSOR_TYPES.contains(&self.0.as_str()) {
+            Action::Continue
+        } else {
+            report(Error::invalid_enum(path(), self.0.clone()))
         }
     }
 }

--- a/src/json/buffer.rs
+++ b/src/json/buffer.rs
@@ -8,7 +8,7 @@
 // except according to those terms.
 
 use json::{Extras, Index, Root};
-use validation::{Error, JsonPath, Validate};
+use validation::{Action, Error, JsonPath, Validate};
 
 /// Corresponds to `GL_ARRAY_BUFFER`.
 pub const ARRAY_BUFFER: u32 = 34962;
@@ -110,26 +110,30 @@ pub struct ByteStride(pub u32);
 pub struct Target(pub u32);
 
 impl Validate for ByteStride {
-    fn validate<P, R>(&self, _: &Root, path: P, report: &mut R)
-        where P: Fn() -> JsonPath, R: FnMut(Error)
+    fn validate<P, R>(&self, _: &Root, path: P, report: &mut R) -> Action
+        where P: Fn() -> JsonPath, R: FnMut(Error) -> Action
     {
         if self.0 % 4 != 0 {
             // Not a multiple of 4
-            report(Error::invalid_value(path(), self.0));
+            try_action!(report(Error::invalid_value(path(), self.0)));
         }
 
         if self.0 < MIN_BYTE_STRIDE || self.0 > MAX_BYTE_STRIDE {
-            report(Error::invalid_value(path(), self.0));
+            try_action!(report(Error::invalid_value(path(), self.0)));
         }
+
+        Action::Continue
     }
 }
 
 impl Validate for Target {
-    fn validate<P, R>(&self, _: &Root, path: P, report: &mut R)
-        where P: Fn() -> JsonPath, R: FnMut(Error)
+    fn validate<P, R>(&self, _: &Root, path: P, report: &mut R) -> Action
+        where P: Fn() -> JsonPath, R: FnMut(Error) -> Action
     {
-        if !VALID_TARGETS.contains(&self.0) {
-            report(Error::invalid_enum(path(), self.0));
+        if VALID_TARGETS.contains(&self.0) {
+            Action::Continue
+        } else {
+            report(Error::invalid_enum(path(), self.0))
         }
     }
 }

--- a/src/json/image.rs
+++ b/src/json/image.rs
@@ -8,7 +8,7 @@
 // except according to those terms.
 
 use json::{buffer, Extras, Index, Root};
-use validation::{Error, JsonPath, Validate};
+use validation::{Action, Error, JsonPath, Validate};
 
 /// All valid MIME types.
 pub const VALID_MIME_TYPES: &'static [&'static str] = &[
@@ -55,11 +55,13 @@ pub struct ImageExtensions {
 pub struct MimeType(pub String);
 
 impl Validate for MimeType {
-    fn validate<P, R>(&self, _: &Root, path: P, report: &mut R)
-        where P: Fn() -> JsonPath, R: FnMut(Error)
+    fn validate<P, R>(&self, _: &Root, path: P, report: &mut R) -> Action
+        where P: Fn() -> JsonPath, R: FnMut(Error) -> Action
     {
-        if !VALID_MIME_TYPES.contains(&self.0.as_str()) {
-            report(Error::invalid_enum(path(), self.0.clone()));
+        if VALID_MIME_TYPES.contains(&self.0.as_str()) {
+            Action::Continue
+        } else {
+            report(Error::invalid_enum(path(), self.0.clone()))
         }
     }
 }

--- a/src/json/material.rs
+++ b/src/json/material.rs
@@ -8,7 +8,7 @@
 // except according to those terms.
 
 use json::{texture, Extras, Index, Root};
-use validation::{Error, JsonPath, Validate};
+use validation::{Action, Error, JsonPath, Validate};
 
 /// All valid alpha modes.
 pub const VALID_ALPHA_MODES: &'static [&'static str] = &[
@@ -247,36 +247,42 @@ impl Default for AlphaMode {
 }
 
 impl Validate for AlphaCutoff {
-    fn validate<P, R>(&self, _: &Root, path: P, report: &mut R)
-        where P: Fn() -> JsonPath, R: FnMut(Error)
+    fn validate<P, R>(&self, _: &Root, path: P, report: &mut R) -> Action
+        where P: Fn() -> JsonPath, R: FnMut(Error) -> Action
     {
         if self.0 < 0.0 {
-            report(Error::invalid_value(path(), self.0));
+            report(Error::invalid_value(path(), self.0))
+        } else {
+            Action::Continue
         }
     }
 }
 
 impl Validate for AlphaMode {
-    fn validate<P, R>(&self, _: &Root, path: P, report: &mut R)
-        where P: Fn() -> JsonPath, R: FnMut(Error)
+    fn validate<P, R>(&self, _: &Root, path: P, report: &mut R) -> Action
+        where P: Fn() -> JsonPath, R: FnMut(Error) -> Action
     {
-        if !VALID_ALPHA_MODES.contains(&self.0.as_str()) {
-            report(Error::invalid_enum(path(), self.0.clone()));
+        if VALID_ALPHA_MODES.contains(&self.0.as_str()) {
+            Action::Continue
+        } else {
+            report(Error::invalid_enum(path(), self.0.clone()))
         }
     }
 }
 
 impl Validate for EmissiveFactor {
-    fn validate<P, R>(&self, _: &Root, path: P, report: &mut R)
-        where P: Fn() -> JsonPath, R: FnMut(Error)
+    fn validate<P, R>(&self, _: &Root, path: P, report: &mut R) -> Action
+        where P: Fn() -> JsonPath, R: FnMut(Error) -> Action
     {
         for x in &self.0 {
             if *x < 0.0 || *x > 1.0 {
-                report(Error::invalid_value(path(), self.0.to_vec()));
-                // Only report once
-                break;
+                try_action!(
+                    report(Error::invalid_value(path(), self.0.to_vec()))
+                );
             }
         }
+
+        Action::Continue
     }
 }
 
@@ -287,16 +293,18 @@ impl Default for PbrBaseColorFactor {
 }
 
 impl Validate for PbrBaseColorFactor {
-    fn validate<P, R>(&self, _: &Root, path: P, report: &mut R)
-        where P: Fn() -> JsonPath, R: FnMut(Error)
+    fn validate<P, R>(&self, _: &Root, path: P, report: &mut R) -> Action
+        where P: Fn() -> JsonPath, R: FnMut(Error) -> Action
     {
         for x in &self.0 {
             if *x < 0.0 || *x > 1.0 {
-                report(Error::invalid_value(path(), self.0.to_vec()));
-                // Only report once
-                break;
+                try_action!(
+                    report(Error::invalid_value(path(), self.0.to_vec()))
+                );
             }
         }
+
+        Action::Continue
     }
 }
 
@@ -307,12 +315,16 @@ impl Default for StrengthFactor {
 }
 
 impl Validate for StrengthFactor {
-    fn validate<P, R>(&self, _: &Root, path: P, report: &mut R)
-        where P: Fn() -> JsonPath, R: FnMut(Error)
+    fn validate<P, R>(&self, _: &Root, path: P, report: &mut R) -> Action
+        where P: Fn() -> JsonPath, R: FnMut(Error) -> Action
     {
         if self.0 < 0.0 || self.0 > 1.0 {
-            report(Error::invalid_value(path(), self.0));
+            try_action!(
+                report(Error::invalid_value(path(), self.0))
+            );
         }
+
+        Action::Continue
     }
 }
 

--- a/src/json/mesh.rs
+++ b/src/json/mesh.rs
@@ -9,7 +9,7 @@
 
 use std::collections::HashMap;
 use json::{accessor, material, Extras, Index, Root};
-use validation::{Error, JsonPath, Validate};
+use validation::{Action, Error, JsonPath, Validate};
 
 /// Corresponds to `GL_POINTS`.
 pub const POINTS: u32 = 0;
@@ -134,23 +134,29 @@ impl Default for Mode {
 }
 
 impl Validate for Mode {
-    fn validate<P, R>(&self, _: &Root, path: P, report: &mut R)
-        where P: Fn() -> JsonPath, R: FnMut(Error)
+    fn validate<P, R>(&self, _: &Root, path: P, report: &mut R) -> Action
+        where P: Fn() -> JsonPath, R: FnMut(Error) -> Action
     {
-        if !VALID_MODES.contains(&self.0) {
-            report(Error::invalid_value(path(), self.0));
+        if VALID_MODES.contains(&self.0) {
+            Action::Continue
+        } else {
+            report(Error::invalid_value(path(), self.0))
         }
     }
 }
 
 impl Validate for MorphTargets {
-    fn validate<P, R>(&self, _: &Root, path: P, report: &mut R)
-        where P: Fn() -> JsonPath, R: FnMut(Error)
+    fn validate<P, R>(&self, _: &Root, path: P, report: &mut R) -> Action
+        where P: Fn() -> JsonPath, R: FnMut(Error) -> Action
     {
         for attr in self.0.keys() {
             if !VALID_MORPH_TARGETS.contains(&attr.as_str()) {
-                report(Error::invalid_value(path().key(attr), attr.clone()));
+                try_action!(
+                    report(Error::invalid_value(path().key(attr), attr.clone()))
+                );
             }
         }
+
+        Action::Continue
     }
 }

--- a/src/json/root.rs
+++ b/src/json/root.rs
@@ -10,7 +10,7 @@
 use std;
 use std::fmt;
 use json::*;
-use validation::{Error, JsonPath, Validate};
+use validation::{Action, Error, JsonPath, Validate};
 
 /// Helper trait for retrieving top-level objects by a universal identifier.
 pub trait Get<T> {
@@ -340,11 +340,13 @@ impl<T> fmt::Display for Index<T> {
 impl<T: Validate> Validate for Index<T>
     where Root: TryGet<T>
 {
-    fn validate<P, R>(&self, root: &Root, path: P, mut report: &mut R)
-        where P: Fn() -> JsonPath, R: FnMut(Error)
+    fn validate<P, R>(&self, root: &Root, path: P, mut report: &mut R) -> Action
+        where P: Fn() -> JsonPath, R: FnMut(Error) -> Action
     {
         if root.try_get(self).is_err() {
-            report(Error::index_out_of_bounds(path()));
+            report(Error::index_out_of_bounds(path()))
+        } else {
+            Action::Continue
         }
     }
 }

--- a/src/json/texture.rs
+++ b/src/json/texture.rs
@@ -8,7 +8,7 @@
 // except according to those terms.
 
 use json::{image, Extras, Index, Root};
-use validation::{Error, JsonPath, Validate};
+use validation::{Action, Error, JsonPath, Validate};
 
 /// Corresponds to `GL_NEAREST`.
 pub const NEAREST: u32 = 9728;
@@ -168,21 +168,25 @@ pub struct MinFilter(pub u32);
 pub struct WrappingMode(pub u32);
 
 impl Validate for MagFilter {
-    fn validate<P, R>(&self, _: &Root, path: P, report: &mut R)
-        where P: Fn() -> JsonPath, R: FnMut(Error)
+    fn validate<P, R>(&self, _: &Root, path: P, report: &mut R) -> Action
+        where P: Fn() -> JsonPath, R: FnMut(Error) -> Action
     {
-        if !VALID_MAG_FILTERS.contains(&self.0) {
-            report(Error::invalid_enum(path(), self.0));
+        if VALID_MAG_FILTERS.contains(&self.0) {
+            Action::Continue
+        } else {
+            report(Error::invalid_enum(path(), self.0))
         }
     }
 }
 
 impl Validate for MinFilter {
-    fn validate<P, R>(&self, _: &Root, path: P, report: &mut R)
-        where P: Fn() -> JsonPath, R: FnMut(Error)
+    fn validate<P, R>(&self, _: &Root, path: P, report: &mut R) -> Action
+        where P: Fn() -> JsonPath, R: FnMut(Error) -> Action
     {
-        if !VALID_MIN_FILTERS.contains(&self.0) {
-            report(Error::invalid_enum(path(), self.0));
+        if VALID_MIN_FILTERS.contains(&self.0) {
+            Action::Continue
+        } else {
+            report(Error::invalid_enum(path(), self.0))
         }
     }
 }
@@ -194,11 +198,13 @@ impl Default for WrappingMode {
 }
 
 impl Validate for WrappingMode {
-    fn validate<P, R>(&self, _: &Root, path: P, report: &mut R)
-        where P: Fn() -> JsonPath, R: FnMut(Error)
+    fn validate<P, R>(&self, _: &Root, path: P, report: &mut R) -> Action
+        where P: Fn() -> JsonPath, R: FnMut(Error) -> Action
     {
-        if !VALID_WRAPPING_MODES.contains(&self.0) {
-            report(Error::invalid_enum(path(), self.0));
+        if VALID_WRAPPING_MODES.contains(&self.0) {
+            Action::Continue
+        } else {
+            report(Error::invalid_enum(path(), self.0))
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,10 @@ extern crate serde;
 extern crate serde_derive;
 extern crate serde_json;
 
+/// Contains the `try_validate` macro.
+#[macro_use]
+mod macros;
+
 /// Contains (de)serializable data structures that represent the glTF JSON data.
 pub mod json;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,24 @@
+
+// Copyright 2017 The gltf Library Developers
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+macro_rules! try_action {
+    ($expr:expr) => {
+        if $expr == ::validation::Action::Stop {
+            return ::validation::Action::Stop;
+        }
+    }
+}
+
+macro_rules! try_validate {
+    ($field:expr, $root:expr, $path:expr, $report:expr) => {
+        if $field.validate($root, $path, $report) == ::validation::Action::Stop {
+            return ::validation::Action::Stop;
+        }
+    }
+}

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -14,13 +14,23 @@ use json::*;
 
 pub use self::error::Error;
 
+/// Specifies whether validation should stop or continue.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum Action {
+    /// Continue the validation process.
+    Continue,
+
+    /// Stop the validation process.
+    Stop,
+}
+
 /// Trait for validating glTF JSON data against the 2.0 specification.
 pub trait Validate {
     /// Validates the data against the glTF 2.0 specification.
-    fn validate<P, R>(&self, root: &Root, path: P, report: &mut R)
+    fn validate<P, R>(&self, root: &Root, path: P, report: &mut R) -> Action
         where
             P: Fn() -> JsonPath,
-            R: FnMut(Error);
+            R: FnMut(Error) -> Action;
 }
 
 /// Contains `Error` and other related data structures.
@@ -208,112 +218,118 @@ impl std::fmt::Display for JsonPath {
 }
 
 impl<T: Validate> Validate for HashMap<String, T> {
-    fn validate<P, R>(&self, root: &Root, path: P, report: &mut R)
-        where P: Fn() -> JsonPath, R: FnMut(Error)
+    fn validate<P, R>(&self, root: &Root, path: P, report: &mut R) -> Action
+        where P: Fn() -> JsonPath, R: FnMut(Error) -> Action
     {
         for (key, value) in self.iter() {
-            value.validate(root, || path().key(key), report);
+            try_validate!(value, root, || path().key(key), report);
         }
+
+        Action::Continue
     }
 }
 
 impl<T: Validate> Validate for Option<T> {
-    fn validate<P, R>(&self, root: &Root, path: P, report: &mut R)
-        where P: Fn() -> JsonPath, R: FnMut(Error)
+    fn validate<P, R>(&self, root: &Root, path: P, report: &mut R) -> Action
+        where P: Fn() -> JsonPath, R: FnMut(Error) -> Action
     {
         if let Some(value) = self.as_ref() {
-            value.validate(root, path, report);
+            try_validate!(value, root, path, report);
         }
+
+        Action::Continue
     }
 }
 
 impl<T: Validate> Validate for Vec<T> {
-    fn validate<P, R>(&self, root: &Root, path: P, report: &mut R)
-        where P: Fn() -> JsonPath, R: FnMut(Error)
+    fn validate<P, R>(&self, root: &Root, path: P, report: &mut R) -> Action
+        where P: Fn() -> JsonPath, R: FnMut(Error) -> Action
     {
         for (index, value) in self.iter().enumerate() {
-            value.validate(root, || path().index(index), report);
+            try_validate!(value, root, || path().index(index), report);
         }
+
+        Action::Continue
     }
 }
 
 impl Validate for bool {
-    fn validate<P, R>(&self, _root: &Root, _path: P, _report: &mut R)
-        where P: Fn() -> JsonPath, R: FnMut(Error)
+    fn validate<P, R>(&self, _root: &Root, _path: P, _report: &mut R) -> Action
+        where P: Fn() -> JsonPath, R: FnMut(Error) -> Action
     {
-        // nop
+        Action::Continue
     }
 }
 
 impl Validate for u32 {
-    fn validate<P, R>(&self, _root: &Root, _path: P, _report: &mut R)
-        where P: Fn() -> JsonPath, R: FnMut(Error)
+    fn validate<P, R>(&self, _root: &Root, _path: P, _report: &mut R) -> Action
+        where P: Fn() -> JsonPath, R: FnMut(Error) -> Action
     {
-        // nop
+        Action::Continue
     }
 }
 
 impl Validate for i32 {
-    fn validate<P, R>(&self, _root: &Root, _path: P, _report: &mut R)
-        where P: Fn() -> JsonPath, R: FnMut(Error)
+    fn validate<P, R>(&self, _root: &Root, _path: P, _report: &mut R) -> Action
+        where P: Fn() -> JsonPath, R: FnMut(Error) -> Action
     {
-        // nop
+        Action::Continue
     }
 }
 
 impl Validate for f32 {
-    fn validate<P, R>(&self, _root: &Root, _path: P, _report: &mut R)
-        where P: Fn() -> JsonPath, R: FnMut(Error)
+    fn validate<P, R>(&self, _root: &Root, _path: P, _report: &mut R) -> Action
+        where P: Fn() -> JsonPath, R: FnMut(Error) -> Action
     {
-        // nop
+        Action::Continue
     }
 }
 
 impl Validate for [f32; 3] {
-    fn validate<P, R>(&self, _root: &Root, _path: P, _report: &mut R)
-        where P: Fn() -> JsonPath, R: FnMut(Error)
+    fn validate<P, R>(&self, _root: &Root, _path: P, _report: &mut R) -> Action
+        where P: Fn() -> JsonPath, R: FnMut(Error) -> Action
     {
-        // nop
+        Action::Continue
     }
 }
 
 impl Validate for [f32; 4] {
-    fn validate<P, R>(&self, _root: &Root, _path: P, _report: &mut R)
-        where P: Fn() -> JsonPath, R: FnMut(Error)
+    fn validate<P, R>(&self, _root: &Root, _path: P, _report: &mut R) -> Action
+        where P: Fn() -> JsonPath, R: FnMut(Error) -> Action
     {
-        // nop
+        Action::Continue
     }
 }
 
 impl Validate for [f32; 16] {
-    fn validate<P, R>(&self, _root: &Root, _path: P, _report: &mut R)
-        where P: Fn() -> JsonPath, R: FnMut(Error)
+    fn validate<P, R>(&self, _root: &Root, _path: P, _report: &mut R) -> Action
+        where P: Fn() -> JsonPath, R: FnMut(Error) -> Action
     {
-        // nop
+        Action::Continue
     }
 }
 
 impl Validate for () {
-    fn validate<P, R>(&self, _root: &Root, _path: P, _report: &mut R)
-        where P: Fn() -> JsonPath, R: FnMut(Error)
+    fn validate<P, R>(&self, _root: &Root, _path: P, _report: &mut R) -> Action
+        where P: Fn() -> JsonPath, R: FnMut(Error) -> Action
     {
-        // nop
+        Action::Continue
     }
 }
 
 impl Validate for String {
-    fn validate<P, R>(&self, _root: &Root, _path: P, _report: &mut R)
-        where P: Fn() -> JsonPath, R: FnMut(Error)
+    fn validate<P, R>(&self, _root: &Root, _path: P, _report: &mut R) -> Action
+        where P: Fn() -> JsonPath, R: FnMut(Error) -> Action
     {
-        // nop
+        Action::Continue
     }
 }
 
 impl Validate for serde_json::Value {
-    fn validate<P, R>(&self, _root: &Root, _path: P, _report: &mut R)
-        where P: Fn() -> JsonPath, R: FnMut(Error)
+    fn validate<P, R>(&self, _root: &Root, _path: P, _report: &mut R) -> Action
+        where P: Fn() -> JsonPath, R: FnMut(Error) -> Action
     {
-        // nop
+        Action::Continue
     }
 }
 


### PR DESCRIPTION
This is achieved using a new type, namely `Action`, which can take the value `Stop` or `Continue`. The validation callback decides whether the continue the validation or not.