### PR TITLE
Add `as_gl_enum()` to MagFilter, MinFilter, WrappingMode

### DIFF
--- a/src/json/mesh.rs
+++ b/src/json/mesh.rs
@@ -53,7 +53,7 @@ pub const VALID_MORPH_TARGETS: &'static [&'static str] = &[
 ];
 
 /// The type of primitives to render.
-#[derive(Clone, Copy, Debug, Deserialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq)]
 pub enum Mode {
     /// Corresponds to `GL_POINTS`.
     Points = 1,

--- a/src/json/texture.rs
+++ b/src/json/texture.rs
@@ -72,6 +72,16 @@ pub enum MagFilter {
     Linear,
 }
 
+impl MagFilter {
+    /// OpenGL enum
+    pub fn as_gl_enum(&self) -> i32 {
+        match *self {
+            MagFilter::Nearest => NEAREST as i32,
+            MagFilter::Linear => LINEAR as i32,
+        }
+    }
+}
+
 /// Minification filter.
 #[derive(Clone, Copy, Debug, Deserialize)]
 pub enum MinFilter {
@@ -94,6 +104,20 @@ pub enum MinFilter {
     LinearMipmapLinear,
 }
 
+impl MinFilter {
+    /// OpenGL enum
+    pub fn as_gl_enum(&self) -> i32 {
+        match *self {
+            MinFilter::Nearest => NEAREST as i32,
+            MinFilter::Linear => LINEAR as i32,
+            MinFilter::NearestMipmapNearest => NEAREST_MIPMAP_NEAREST as i32,
+            MinFilter::LinearMipmapNearest => LINEAR_MIPMAP_NEAREST as i32,
+            MinFilter::NearestMipmapLinear => NEAREST_MIPMAP_LINEAR as i32,
+            MinFilter::LinearMipmapLinear => LINEAR_MIPMAP_LINEAR as i32,
+        }
+    }
+}
+
 /// Texture co-ordinate wrapping mode.
 #[derive(Clone, Copy, Debug, Deserialize)]
 pub enum WrappingMode {
@@ -105,6 +129,17 @@ pub enum WrappingMode {
 
     /// Corresponds to `GL_REPEAT`.
     Repeat,
+}
+
+impl WrappingMode {
+    /// OpenGL enum
+    pub fn as_gl_enum(&self) -> i32 {
+        match *self {
+            WrappingMode::ClampToEdge => CLAMP_TO_EDGE as i32,
+            WrappingMode::MirroredRepeat => MIRRORED_REPEAT as i32,
+            WrappingMode::Repeat => REPEAT as i32,
+        }
+    }
 }
 
 /// Texture sampler properties for filtering and wrapping modes.


### PR DESCRIPTION
Also: derive PartialEq for json::mesh::Mode.

For usage examples, see https://github.com/bwasty/gltf-viewer/compare/gltf_changes.


