### PR TITLE
gltf-importer: re-export ValidationStrategy like Config

### DIFF
--- a/gltf-importer/src/lib.rs
+++ b/gltf-importer/src/lib.rs
@@ -39,6 +39,7 @@ use std::path::Path;
 pub mod config;
 
 pub use self::config::Config;
+pub use self::config::ValidationStrategy;
 
 /// Error encountered when importing a glTF 2.0 asset.
 #[derive(Debug)]


### PR DESCRIPTION
Tiny improvement to enable one-line import: 
```
use gltf_importer::{ Config, ValidationStrategy };
```